### PR TITLE
Pin FastAPI stack dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-fastapi
-uvicorn
-
-httpx
-
+fastapi==0.97.0
+uvicorn==0.27.0.post1
+httpx==0.27.0


### PR DESCRIPTION
## Summary
- pin `fastapi`, `uvicorn` and `httpx` versions in `requirements.txt`
- attempt to install requirements

## Testing
- `pip install -r requirements.txt` *(fails: no route to host)*
- `python -m unittest discover tests`