### PR TITLE
Add version constant and README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,12 @@ Execute the unit tests with:
 python -m unittest discover tests
 ```
 
+## Package Version
+
+You can check the installed version programmatically:
+
+```python
+from src import __version__
+print(__version__)
+```
+

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,9 @@
+
+"""Package initialization for :mod:`src`."""
+
+__version__ = "0.1.0"
+
+# Re-export the main components for convenience
+from .agent import TutorAgent
+
+__all__ = ["TutorAgent", "__version__"]


### PR DESCRIPTION
## Summary
- set package `__version__` in `src/__init__.py`
- re-export `TutorAgent` from package init for convenience
- document how to read the version in README

## Testing
- `python -m unittest discover tests`