### PR TITLE
Add React frontend skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ venv/
 .env
 .pytest_cache/
 *.log
+node_modules/

--- a/README.md
+++ b/README.md
@@ -37,3 +37,31 @@ from src import __version__
 print(__version__)
 ```
 
+## Frontend
+
+The `frontend/` directory contains a React application built with Vite.
+
+### Development server
+
+Ensure Node.js (>=18) and npm are installed. Then run:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The app will be served at `http://localhost:3000`.
+
+### Production build
+
+To create an optimized build:
+
+```bash
+cd frontend
+npm install
+npm run build
+```
+
+The static files will be generated in `frontend/dist/`.
+

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LumLearn</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "frontend",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.17.0",
+    "framer-motion": "^10.12.16",
+    "lucide-react": "^0.357.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.4.9"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { HashRouter, Routes, Route } from 'react-router-dom';
+import { AppProvider } from './context/AppContext';
+import GlobalHeader from './components/GlobalHeader';
+import MobileBottomNav from './components/MobileBottomNav';
+import ToastContainer from './components/ToastContainer';
+import LandingDashboardPage from './pages/LandingDashboardPage';
+import TutorChatWorkspacePage from './pages/TutorChatWorkspacePage';
+import LibraryPage from './pages/LibraryPage';
+import NotificationsPage from './pages/NotificationsPage';
+import ProfilePage from './pages/ProfilePage';
+
+const AppRoutes = () => (
+  <Routes>
+    <Route path="/" element={<LandingDashboardPage />} />
+    <Route path="/tutor" element={<TutorChatWorkspacePage />} />
+    <Route path="/library" element={<LibraryPage />} />
+    <Route path="/notifications" element={<NotificationsPage />} />
+    <Route path="/profile" element={<ProfilePage />} />
+    <Route path="*" element={<div className="p-4">Page Not Found</div>} />
+  </Routes>
+);
+
+const App = () => (
+  <HashRouter>
+    <AppProvider>
+      <div className="flex flex-col min-h-screen">
+        <GlobalHeader />
+        <main className="flex-grow">
+          <AppRoutes />
+        </main>
+        <ToastContainer />
+        <MobileBottomNav />
+      </div>
+    </AppProvider>
+  </HashRouter>
+);
+
+export default App;

--- a/frontend/src/components/GlobalHeader.jsx
+++ b/frontend/src/components/GlobalHeader.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const GlobalHeader = () => (
+  <header className="bg-primary text-white h-16 flex items-center px-4">
+    <h1 className="text-xl font-semibold mr-4">LumLearn</h1>
+    <nav className="space-x-4">
+      <Link to="/" className="hover:underline">Dashboard</Link>
+      <Link to="/tutor" className="hover:underline">Tutor</Link>
+      <Link to="/library" className="hover:underline">Library</Link>
+    </nav>
+  </header>
+);
+
+export default GlobalHeader;

--- a/frontend/src/components/MobileBottomNav.jsx
+++ b/frontend/src/components/MobileBottomNav.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Link, useLocation } from 'react-router-dom';
+
+const MobileBottomNav = () => {
+  const location = useLocation();
+  const items = [
+    { path: '/', label: 'Dashboard' },
+    { path: '/tutor', label: 'Tutor' },
+    { path: '/library', label: 'Library' }
+  ];
+
+  return (
+    <nav className="md:hidden fixed bottom-0 left-0 right-0 bg-white shadow-inner h-16 flex justify-around items-center">
+      {items.map(item => (
+        <Link
+          key={item.path}
+          to={item.path}
+          className={location.pathname === item.path ? 'text-primary font-semibold' : 'text-gray-600'}
+        >
+          {item.label}
+        </Link>
+      ))}
+    </nav>
+  );
+};
+
+export default MobileBottomNav;

--- a/frontend/src/components/Toast.jsx
+++ b/frontend/src/components/Toast.jsx
@@ -1,0 +1,16 @@
+import React, { useEffect } from 'react';
+
+const Toast = ({ message, onClose }) => {
+  useEffect(() => {
+    const timer = setTimeout(onClose, 3000);
+    return () => clearTimeout(timer);
+  }, [onClose]);
+
+  return (
+    <div className="bg-gray-900 text-white px-4 py-2 rounded shadow">
+      {message}
+    </div>
+  );
+};
+
+export default Toast;

--- a/frontend/src/components/ToastContainer.jsx
+++ b/frontend/src/components/ToastContainer.jsx
@@ -1,0 +1,26 @@
+import React, { useState, useCallback } from 'react';
+import Toast from './Toast';
+
+let idCounter = 0;
+
+const ToastContainer = () => {
+  const [toasts, setToasts] = useState([]);
+
+  const addToast = useCallback((message) => {
+    setToasts((prev) => [...prev, { id: idCounter++, message }]);
+  }, []);
+
+  const removeToast = useCallback((id) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  return (
+    <div className="fixed top-4 right-4 space-y-2 z-50">
+      {toasts.map((toast) => (
+        <Toast key={toast.id} message={toast.message} onClose={() => removeToast(toast.id)} />
+      ))}
+    </div>
+  );
+};
+
+export default ToastContainer;

--- a/frontend/src/context/AppContext.jsx
+++ b/frontend/src/context/AppContext.jsx
@@ -1,0 +1,39 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
+const AppContext = createContext();
+
+export const AppProvider = ({ children }) => {
+  const [currentUser, setCurrentUser] = useState({ name: 'Student' });
+  const [notifications, setNotifications] = useState([]);
+  const [isOffline, setIsOffline] = useState(false);
+  const [toasts, setToasts] = useState([]);
+
+  const addToast = (message) => {
+    setToasts((prev) => [...prev, { id: Date.now(), message }]);
+  };
+
+  const removeToast = (id) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  };
+
+  useEffect(() => {
+    const handleOffline = () => setIsOffline(true);
+    const handleOnline = () => setIsOffline(false);
+    window.addEventListener('offline', handleOffline);
+    window.addEventListener('online', handleOnline);
+    return () => {
+      window.removeEventListener('offline', handleOffline);
+      window.removeEventListener('online', handleOnline);
+    };
+  }, []);
+
+  return (
+    <AppContext.Provider
+      value={{ currentUser, notifications, isOffline, toasts, addToast, removeToast }}
+    >
+      {children}
+    </AppContext.Provider>
+  );
+};
+
+export const useAppContext = () => useContext(AppContext);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,44 @@
+body {
+  margin: 0;
+  font-family: Inter, sans-serif;
+}
+
+.bg-primary { background-color: #2563EB; }
+.text-primary { color: #2563EB; }
+.hover\:underline:hover { text-decoration: underline; }
+
+.bg-gray-100 { background-color: #f3f4f6; }
+.bg-gray-900 { background-color: #111827; }
+.text-white { color: #ffffff; }
+.text-gray-600 { color: #4b5563; }
+.text-gray-700 { color: #374151; }
+.rounded { border-radius: 0.25rem; }
+.rounded-l { border-top-left-radius: 0.25rem; border-bottom-left-radius: 0.25rem; }
+.rounded-r { border-top-right-radius: 0.25rem; border-bottom-right-radius: 0.25rem; }
+.rounded-full { border-radius: 9999px; }
+.p-2 { padding: 0.5rem; }
+.p-4 { padding: 1rem; }
+.px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
+.px-4 { padding-left: 1rem; padding-right: 1rem; }
+.py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
+.mx-auto { margin-left: auto; margin-right: auto; }
+.flex { display: flex; }
+.flex-col { flex-direction: column; }
+.flex-grow { flex: 1 1 auto; }
+.h-16 { height: 4rem; }
+.fixed { position: fixed; }
+.bottom-0 { bottom: 0; }
+.left-0 { left: 0; }
+.right-0 { right: 0; }
+.top-4 { top: 1rem; }
+.shadow-inner { box-shadow: inset 0 2px 4px 0 rgba(0,0,0,0.06); }
+.shadow { box-shadow: 0 1px 2px 0 rgba(0,0,0,0.05); }
+.bg-white { background-color: #ffffff; }
+.container { max-width: 1024px; }
+.mb-4 { margin-bottom: 1rem; }
+.space-y-2 > :not([hidden]) ~ :not([hidden]) { margin-top: 0.5rem; }
+.h-4 { height: 1rem; }
+.h-6 { height: 1.5rem; }
+.h-[calc(100vh-4rem)] { height: calc(100vh - 4rem); }
+.overflow-y-auto { overflow-y: auto; }
+

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/pages/LandingDashboardPage.jsx
+++ b/frontend/src/pages/LandingDashboardPage.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const LandingDashboardPage = () => (
+  <div className="p-4">
+    <h2 className="text-2xl font-semibold mb-4">Welcome to LumLearn</h2>
+    <p className="text-gray-700">This is a simplified dashboard page.</p>
+  </div>
+);
+
+export default LandingDashboardPage;

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const LibraryPage = () => (
+  <div className="p-4">
+    <h2 className="text-2xl font-semibold mb-4">Library</h2>
+    <p className="text-gray-700">Your saved materials will appear here.</p>
+  </div>
+);
+
+export default LibraryPage;

--- a/frontend/src/pages/NotificationsPage.jsx
+++ b/frontend/src/pages/NotificationsPage.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const NotificationsPage = () => (
+  <div className="p-4">
+    <h2 className="text-2xl font-semibold mb-4">Notifications</h2>
+    <p className="text-gray-700">You have no new notifications.</p>
+  </div>
+);
+
+export default NotificationsPage;

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { useAppContext } from '../context/AppContext';
+
+const ProfilePage = () => {
+  const { currentUser } = useAppContext();
+  return (
+    <div className="p-4">
+      <h2 className="text-2xl font-semibold mb-4">Profile</h2>
+      <p className="text-gray-700">Logged in as {currentUser.name}.</p>
+    </div>
+  );
+};
+
+export default ProfilePage;

--- a/frontend/src/pages/TutorChatWorkspacePage.jsx
+++ b/frontend/src/pages/TutorChatWorkspacePage.jsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import { useAppContext } from '../context/AppContext';
+
+const TutorChatWorkspacePage = () => {
+  const [messages, setMessages] = useState([]);
+  const { currentUser } = useAppContext();
+
+  const handleSend = (e) => {
+    e.preventDefault();
+    const form = e.target;
+    const value = form.elements.message.value;
+    if (!value) return;
+    setMessages([...messages, { sender: currentUser.name, text: value }]);
+    form.reset();
+  };
+
+  return (
+    <div className="p-4 flex flex-col h-[calc(100vh-4rem)]">
+      <div className="flex-grow overflow-y-auto space-y-2">
+        {messages.map((msg, idx) => (
+          <div key={idx} className="bg-gray-100 p-2 rounded">
+            <strong>{msg.sender}: </strong>{msg.text}
+          </div>
+        ))}
+      </div>
+      <form onSubmit={handleSend} className="mt-2 flex">
+        <input name="message" className="flex-grow border rounded-l px-2" placeholder="Say something" />
+        <button type="submit" className="bg-primary text-white px-4 rounded-r">Send</button>
+      </form>
+    </div>
+  );
+};
+
+export default TutorChatWorkspacePage;

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000
+  }
+});


### PR DESCRIPTION
## Summary
- initialize a Vite-based React project in `frontend/`
- split the large LumLearn prototype into smaller components and pages
- add minimal styling and context provider
- document build instructions and ignore `node_modules`

## Testing
- `python -m unittest discover tests -v` *(fails: ModuleNotFoundError: No module named 'httpx')*