### PR TITLE
Move project design to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lumina Learn
 
-This repository contains an early prototype of **Lumina Learn**, an AI-powered study companion inspired by the design document in the `Project` file.
+This repository contains an early prototype of **Lumina Learn**, an AI-powered study companion inspired by the [design document](docs/design.md).
 
 ## Running the API
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,3 +1,5 @@
+# Lumina Learn Design Document
+
 Below is a **strategy-level design blueprint** for a next-generation study app that takes full advantage of the AI capabilities Google unveiled at I/O 2025. I’ve emphasised modularity so you can roll out a core web/mobile product quickly, then layer on the flashier XR and multimodal features as Google’s SDKs mature.
 
 ---
@@ -16,7 +18,7 @@ Below is a **strategy-level design blueprint** for a next-generation study app t
 
 ## 2  High-Level Architecture
 
-```
+```text
  ┌────────────────────────────┐
  │   Front-End Clients        │
  │ ────────────────────────── │


### PR DESCRIPTION
## Summary
- rename `Project` -> `docs/design.md`
- add heading and tweak architecture code block
- link to new design doc from `README.md`

## Testing
- `pip install -r requirements.txt` *(fails: No route to host)*
- `python -m unittest discover tests` *(fails: ModuleNotFoundError: No module named 'httpx')*