### PR TITLE
Fix module docstring placement

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,3 @@
-
 """Package initialization for :mod:`src`."""
 
 __version__ = "0.1.0"


### PR DESCRIPTION
## Summary
- move the src module docstring to the first line

## Testing
- `pytest -q` *(fails: pytest not installed)*