### PR TITLE
Add async TutorAgent ask

### DIFF
--- a/src/agent.py
+++ b/src/agent.py
@@ -1,9 +1,10 @@
 class TutorAgent:
     """Simple placeholder TutorAgent that returns canned responses."""
 
-    def ask(self, question: str) -> str:
+    async def ask(self, question: str) -> str:
         """Return a placeholder answer for a given question."""
         if not question:
             raise ValueError("Question must not be empty")
         # In a real implementation, integrate with an LLM or RAG pipeline.
+        # The method is asynchronous to mimic calls to external services.
         return f"This is a placeholder answer to: '{question}'"

--- a/src/main.py
+++ b/src/main.py
@@ -25,7 +25,7 @@ async def health() -> dict:
 async def ask_question(question: Question) -> Answer:
     """Ask the TutorAgent a question."""
     try:
-        answer_text = agent.ask(question.question)
+        answer_text = await agent.ask(question.question)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return Answer(answer=answer_text)


### PR DESCRIPTION
## Summary
- convert `TutorAgent.ask` to `async`
- await agent calls in `/ask` endpoint
- convert API tests to async using `httpx.AsyncClient`

## Testing
- `python -m unittest discover -s tests -p '*.py' -v` *(fails: ModuleNotFoundError: No module named 'httpx')*