### PR TITLE
Add JSON validation and error handlers

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,10 +1,46 @@
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from .agent import TutorAgent
 
 app = FastAPI(title="Lumina Learn API")
 agent = TutorAgent()
+
+
+@app.exception_handler(HTTPException)
+async def handle_http_exception(request: Request, exc: HTTPException) -> JSONResponse:
+    """Return JSON responses for HTTP errors."""
+    status = exc.status_code
+    detail = exc.detail
+    if status == 400 and detail == "There was an error parsing the body":
+        status = 422
+        detail = "Malformed JSON"
+    return JSONResponse(status_code=status, content={"detail": detail})
+
+
+@app.exception_handler(RequestValidationError)
+async def handle_validation_error(
+    request: Request, exc: RequestValidationError
+) -> JSONResponse:
+    """Simplify validation errors to a consistent JSON structure."""
+    errors = exc.errors()
+    is_json_error = (
+        len(errors) == 1 and errors[0].get("type") == "value_error.jsondecode"
+    )
+    if is_json_error:
+        return JSONResponse(status_code=422, content={"detail": "Malformed JSON"})
+    return JSONResponse(
+        status_code=422,
+        content={"detail": "Validation failed", "errors": errors},
+    )
+
+
+@app.exception_handler(Exception)
+async def handle_general_exception(request: Request, exc: Exception) -> JSONResponse:
+    """Catch-all handler for unexpected errors."""
+    return JSONResponse(status_code=500, content={"detail": "Internal Server Error"})
 
 
 class Question(BaseModel):
@@ -25,7 +61,7 @@ async def health() -> dict:
 async def ask_question(question: Question) -> Answer:
     """Ask the TutorAgent a question."""
     try:
-        answer_text = agent.ask(question.question)
+        answer_text = agent.ask(question.question.strip())
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return Answer(answer=answer_text)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 
@@ -25,6 +26,21 @@ class APITestCase(unittest.TestCase):
         response = client.post("/ask", json={"question": ""})
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json(), {"detail": "Question must not be empty"})
+
+    def test_invalid_json(self):
+        response = client.post(
+            "/ask",
+            data="{",
+            headers={"Content-Type": "application/json"},
+        )
+        self.assertEqual(response.status_code, 422)
+        self.assertEqual(response.json(), {"detail": "Malformed JSON"})
+
+    def test_unexpected_error(self):
+        with patch("src.main.agent.ask", side_effect=RuntimeError("boom")):
+            response = client.post("/ask", json={"question": "Hello"})
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.json(), {"detail": "Internal Server Error"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- validate incoming JSON in FastAPI app
- return unified JSON bodies for errors including malformed payloads
- handle uncaught exceptions with 500 status
- test malformed JSON and server errors

## Testing
- `python -m unittest discover tests` *(fails: ModuleNotFoundError: No module named 'httpx')*