### PR TITLE
Refactor ToastContainer context usage

### DIFF
--- a/frontend/src/components/ToastContainer.jsx
+++ b/frontend/src/components/ToastContainer.jsx
@@ -3,7 +3,7 @@ import Toast from './Toast';
 import { useAppContext } from '../context/AppContext';
 
 const ToastContainer = () => {
-  const { toasts, addToast, removeToast } = useAppContext();
+  const { toasts, removeToast } = useAppContext();
 
   return (
     <div className="fixed top-4 right-4 space-y-2 z-50">


### PR DESCRIPTION
## Summary
- clean up context usage in `ToastContainer` by only using `toasts` and `removeToast`

## Testing
- `python -m unittest discover tests` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `npm run build` in `frontend/` *(fails: vite not found)*